### PR TITLE
Errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,12 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     let config = Config::build(&args).unwrap_or_else(|err| {
-        println!("Problem parsing arguments: {err}");
+        eprintln!("Problem parsing arguments: {err}");
         process::exit(1);
     });
 
     if let Err(e) = minigrep::run(config) {
-        println!("Application error: {e}");
+        eprintln!("Application error: {e}");
         process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,6 @@ fn main() {
         println!("Problem parsing arguments: {err}");
         process::exit(1);
     });
-    // sanity checks
-    println!("Searching for {}", config.query);
-    println!("In file {}", config.file_path);
 
     if let Err(e) = minigrep::run(config) {
         println!("Application error: {e}");


### PR DESCRIPTION
write errors to std error instead of std out:

`println!() -> eprintln!()` in `main.rs`